### PR TITLE
Added support for lhco.gz files

### DIFF
--- a/LHCO_reader/LHCO_reader.py
+++ b/LHCO_reader/LHCO_reader.py
@@ -348,6 +348,9 @@ class Events(list):
                 self.LHCO_name = LHCO_converter.ROOT_LHCO(f_name)
             elif f_extension == ".lhco":
                 self.LHCO_name = f_name
+            elif f_extension == ".gz":
+                self.iszipfile = True
+                self.LHCO_name = f_name
             else:
                 raise IOError("Unknown file extension: %s" % f_name)
 
@@ -404,34 +407,65 @@ class Events(list):
         n_events = self.n_events
         event = None
 
-        with open(self.LHCO_name, 'r') as LHCO_file:
-
-            for line in parse_lines(LHCO_file):
-
-                if line.startswith("0"):  # New event in file
-
-                    if event:  # Parse previous event, if there is one
-                        self.add_event(event)  # Add Event class
-                    event = [line]  # New event - reset event list
-
-                    # Don't parse more than a particular number of events
-                    if n_events and len(self) == n_events:
-                        warnings.warn("Didn't parse all LHCO events, "
-                                      "by request")
-                        return
-                else:
-
-                    # If there is not a "0", line belongs to current event,
-                    # not a new event - add it to event
-                    try:
-                        event.append(line)
-                    except AttributeError:
-                        warnings.warn("Possibly an event did not start with 0")
-                        event = [line]
-
-            # Parse final event in file - because there isn't a following event
-            # the final event won't be parsed as above
-            self.add_event(event)
+        if iszipfile == True:
+            with gzip.open(self.LHCO_name, 'rb') as LHCO_file:
+    
+                for line in parse_lines(LHCO_file):
+    
+                    if line.startswith("0"):  # New event in file
+    
+                        if event:  # Parse previous event, if there is one
+                            self.add_event(event)  # Add Event class
+                        event = [line]  # New event - reset event list
+    
+                        # Don't parse more than a particular number of events
+                        if n_events and len(self) == n_events:
+                            warnings.warn("Didn't parse all LHCO events, "
+                                          "by request")
+                            return
+                    else:
+    
+                        # If there is not a "0", line belongs to current event,
+                        # not a new event - add it to event
+                        try:
+                            event.append(line)
+                        except AttributeError:
+                            warnings.warn("Possibly an event did not start with 0")
+                            event = [line]
+    
+                # Parse final event in file - because there isn't a following event
+                # the final event won't be parsed as above
+                self.add_event(event)
+            
+            else:
+                with open(self.LHCO_name, 'r') as LHCO_file:
+    
+                for line in parse_lines(LHCO_file):
+    
+                    if line.startswith("0"):  # New event in file
+    
+                        if event:  # Parse previous event, if there is one
+                            self.add_event(event)  # Add Event class
+                        event = [line]  # New event - reset event list
+    
+                        # Don't parse more than a particular number of events
+                        if n_events and len(self) == n_events:
+                            warnings.warn("Didn't parse all LHCO events, "
+                                          "by request")
+                            return
+                    else:
+    
+                        # If there is not a "0", line belongs to current event,
+                        # not a new event - add it to event
+                        try:
+                            event.append(line)
+                        except AttributeError:
+                            warnings.warn("Possibly an event did not start with 0")
+                            event = [line]
+    
+                # Parse final event in file - because there isn't a following event
+                # the final event won't be parsed as above
+                self.add_event(event)
 
     def number(self, anti_lepton=False):
         """


### PR DESCRIPTION
When you run the Madgraph-Pythia-Delphes event generation chain, Delphes runs root2lhco on the final root files, and then compresses them. The final LHCO files are zipped and will have names of the form tag_1_delphes_events.lhco.gz. This change enables LHCO_reader to process them.
